### PR TITLE
Multi versions

### DIFF
--- a/manifests/tool.pp
+++ b/manifests/tool.pp
@@ -59,7 +59,7 @@ define hashicorp::tool(
 
   ensure_packages(['unzip', 'wget'], {'ensure' => 'present'})
 
-  archive { "install ${tool}":
+  archive { "install ${tool}-${version}":
     provider     => 'wget',
     path         => "${tmp_dir}/${tool}.${ext}",
     extract_path => $bin_dir,

--- a/manifests/tool.pp
+++ b/manifests/tool.pp
@@ -50,7 +50,7 @@ define hashicorp::tool(
 
   validate_re("${tool}", $supported_tool_names, "The provided tool (${tool}) is not currently supported.")
   validate_re("${version}", '^[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}(?:-rc[0-9]{1,2})?', "The provided version (${version}) is not valid.")
-  validate_absolute_path("${bin_dir}") 
+  validate_absolute_path("${bin_dir}")
 
   $release_url = 'https://releases.hashicorp.com'
   $tool_url    = "${release_url}/${tool}"

--- a/manifests/tool.pp
+++ b/manifests/tool.pp
@@ -61,7 +61,7 @@ define hashicorp::tool(
 
   archive { "install ${tool}-${version}":
     provider     => 'wget',
-    path         => "${tmp_dir}/${tool}.${ext}",
+    path         => "${tmp_dir}/${tool}-${version}.${ext}",
     extract_path => $bin_dir,
     source       => $os_url,
     extract      => true,


### PR DESCRIPTION
This update allows you to install multiple versions of the same Hashicorp tool. It allows a configuration like this:

```
hashicorp::tool {'terraform9':
    tool       => 'terraform',
    version => '0.9.0',
    bin_dir  => '/home/jenkins/.tfenv/versions/0.9.0'
}
hashicorp::tool {'terraform10':
    tool       => 'terraform',
    version => '0.10.0',
    bin_dir  => '/home/jenkins/.tfenv/versions/0.10.0'
}
```
